### PR TITLE
Fix fetch images hanging

### DIFF
--- a/src/dataset_tools/fetch_images.py
+++ b/src/dataset_tools/fetch_images.py
@@ -50,7 +50,7 @@ def url_retrieve(url, file_path, timeout):
         )
     }
 
-    r = requests.get(url, timeout=(timeout, None), headers=headers)
+    r = requests.get(url, timeout=(timeout, timeout * 10), headers=headers)
     open(file_path, "wb").write(r.content)
 
 

--- a/src/dataset_tools/verify_images.py
+++ b/src/dataset_tools/verify_images.py
@@ -74,7 +74,7 @@ def verify_image(image_data, dataset_path: str):
     type=str,
     help=(
         "Checkpoint with partial verification results. If provided, the verification "
-        "continues from a previous execition skipping the already verfied images."
+        "continues from a previous execution, skipping the already verfied images."
     ),
 )
 @click.option(
@@ -193,6 +193,7 @@ def main(
     verif_df = pd.merge(gbif_metadata, verif_df, how="inner", on="image_path")
     verif_df.to_csv(results_csv, index=False)
     errors_df.to_csv(results_csv + ".error.csv", index=False)
+    print(f"Final verification results saved to {results_csv}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replaced urllib.request with requests in order to add a timeout and user agent, thus avoiding the hanging of image retrieval.